### PR TITLE
ci: update npm before publish to fix OIDC publishing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,6 +68,9 @@ jobs:
           registry-url: https://registry.npmjs.org/
           node-version: lts/*
 
+      - name: Update npm
+        run: npm install -g npm
+
       - name: Download build artifacts
         uses: actions/download-artifact@v5
         with:


### PR DESCRIPTION
Added a step to update npm to the latest version before downloading build artifacts.

BEGIN_COMMIT_OVERRIDE
fix(publish): update npm before publish to fix OIDC publishing
END_COMMIT_OVERRIDE