### PR TITLE
fix: remove dependency on vite, don't leak vite Plugin

### DIFF
--- a/build.config.ts
+++ b/build.config.ts
@@ -3,7 +3,11 @@ import { defineBuildConfig } from "unbuild"
 export default defineBuildConfig({
   outDir: "dist",
   entries: ["src/index", "src/i18n.client", "src/i18n.server", "src/routes", "src/plugin/index"],
-  externals: ["virtual:lingui-router-loader", "virtual:lingui-router-manifest"],
+  externals: [
+    "virtual:lingui-router-loader",
+    "virtual:lingui-router-manifest",
+    /^virtual:lingui-router-locale-.*/,
+  ],
   declaration: true,
   rollup: {
     emitCJS: true,

--- a/package.json
+++ b/package.json
@@ -70,7 +70,8 @@
     "rollup": "^4.52.5",
     "tsx": "^4.20.6",
     "typescript": "^5.9.3",
-    "unbuild": "^3.6.1"
+    "unbuild": "^3.6.1",
+    "vite": "^7.1.7"
   },
   "peerDependencies": {
     "@lingui/conf": "^5.5.0",
@@ -78,7 +79,6 @@
     "@lingui/react": "^5.5.0",
     "@react-router/dev": "^7.9.3",
     "react": "^19.1.1",
-    "react-router": "^7.9.3",
-    "vite": "^7.1.7"
+    "react-router": "^7.9.3"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,9 +32,6 @@ importers:
       react-router:
         specifier: ^7.9.3
         version: 7.9.4(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      vite:
-        specifier: ^7.1.7
-        version: 7.1.12(@types/node@22.18.12)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.20.6)
     devDependencies:
       '@types/negotiator':
         specifier: ^0.6.4
@@ -63,6 +60,9 @@ importers:
       unbuild:
         specifier: ^3.6.1
         version: 3.6.1(typescript@5.9.3)
+      vite:
+        specifier: ^7.1.7
+        version: 7.1.12(@types/node@22.18.12)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.20.6)
 
   test:
     dependencies:

--- a/src/i18n.server.ts
+++ b/src/i18n.server.ts
@@ -79,7 +79,7 @@ export function useLinguiServer(context: Readonly<RouterContextProvider>): I18nR
  * AsyncLocalStorage context containing i18n and request metadata.
  */
 export async function localeMiddleware(
-  { request, context }: Readonly<{ request: Request; context: RouterContextProvider }>,
+  { request, context }: { request: Request; context: Readonly<RouterContextProvider> },
   next: () => Promise<Response>
 ): Promise<Response> {
   const url = new URL(request.url)
@@ -127,7 +127,7 @@ export async function localeMiddleware(
 function getAcceptedLocale(acceptLanguage?: string | null): string | undefined {
   if (!acceptLanguage) return
 
-  const negotiator = new Negotiator({ headers: { 'accept-language': acceptLanguage } })
+  const negotiator = new Negotiator({ headers: { "accept-language": acceptLanguage } })
   const accepted = negotiator.languages(config.locales.slice())
 
   return accepted[0]

--- a/test/app/root.tsx
+++ b/test/app/root.tsx
@@ -26,7 +26,7 @@ export function meta({}: Route.MetaArgs) {
   ]
 }
 
-function RootLayout({ children }: { children: ReactNode }) {
+function RootLayout({ children }: Readonly<{ children: ReactNode }>) {
   const { i18n } = useLingui()
 
   return (
@@ -50,7 +50,7 @@ function RootLayout({ children }: { children: ReactNode }) {
   )
 }
 
-export function Layout({ children }: { children: ReactNode }) {
+export function Layout({ children }: Readonly<{ children: ReactNode }>) {
   return (
     <I18nApp>
       <RootLayout>{children}</RootLayout>

--- a/test/package.json
+++ b/test/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "scripts": {
     "extract": "lingui extract",
-    "prebuild": "lingui extract --clean",
+    "prebuild": "react-router typegen && tsc --noEmit --strict && lingui extract --clean",
     "build": "react-router build",
     "dev": "react-router dev",
     "start": "react-router-serve ./build/server/index.js"

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -1,33 +1,16 @@
 {
-  "include": [
-    "**/*",
-    "**/.server/**/*",
-    "**/.client/**/*",
-    ".react-router/types/**/*"
-  ],
+  "include": ["**/*", "**/.server/**/*", "**/.client/**/*", ".react-router/types/**/*"],
   "compilerOptions": {
-    "lib": [
-      "DOM",
-      "DOM.Iterable",
-      "ES2022"
-    ],
-    "types": [
-      "node",
-      "vite/client"
-    ],
+    "lib": ["DOM", "DOM.Iterable", "ES2022"],
+    "types": ["node", "vite/client"],
     "target": "ES2022",
     "module": "ES2022",
     "moduleResolution": "bundler",
     "jsx": "react-jsx",
-    "rootDirs": [
-      ".",
-      "./.react-router/types"
-    ],
+    "rootDirs": [".", "./.react-router/types"],
     "baseUrl": ".",
     "paths": {
-      "~/*": [
-        "./app/*"
-      ]
+      "~/*": ["./app/*"]
     },
     "esModuleInterop": true,
     "verbatimModuleSyntax": true,
@@ -35,5 +18,6 @@
     "resolveJsonModule": true,
     "skipLibCheck": true,
     "strict": true
-  }
+  },
+  "exclude": ["dist"]
 }


### PR DESCRIPTION
- Removed vite from peerDependencies
- linguiRouterPlugin now returns any to avoid any dependency on vite
- Added typecheck to test project