### PR TITLE
fix: further optimize usePathLocale, main logic now moved to I18nApp

### DIFF
--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -1,7 +1,11 @@
-import { useMemo } from "react"
-import { useLocation, useParams } from "react-router"
+import React from "react"
 import { normalizeLocaleKey } from "./config"
-import { $useLingui, config, localeMapping, supportedLocales } from "./runtime"
+import { config, localeMapping, supportedLocales } from "./runtime"
+
+/**
+ * The context for locale information derived from the URL path.
+ */
+export const LocalePathContext = React.createContext<PathLocale | null>(null)
 
 /**
  * Represents the locale information derived from the URL path.
@@ -24,29 +28,11 @@ export type PathLocale = {
  * - `requestPathname` - The pathname without the locale prefix
  */
 export function usePathLocale(): PathLocale {
-  const location = useLocation()
-  const params = useParams()
-  const { i18n } = $useLingui()
-  const localeParamName = config.localeParamName
-
-  return useMemo(() => {
-    const localeParam = params[localeParamName]
-    // This is a shortcut - we assume that if localeParam is present, i18n.locale has
-    // the corresponding locale code (normalized and found in supportedLocales)
-    // This is ensured by I18nApp component
-    const requestLocale = localeParam ? i18n.locale : undefined
-
-    // Use relative pathname only if locale is in the URL
-    const requestPathname = localeParam
-      ? stripPathnameLocalePrefix(location.pathname, localeParam)
-      : location.pathname
-
-    return {
-      requestLocale,
-      locale: i18n.locale,
-      requestPathname,
-    }
-  }, [params[localeParamName], location.pathname, i18n.locale])
+  const context = React.useContext(LocalePathContext)
+  if (!context) {
+    throw new Error("usePathLocale must be used within a I18nApp component")
+  }
+  return context
 }
 
 /**

--- a/src/server/context.ts
+++ b/src/server/context.ts
@@ -26,7 +26,7 @@ export type I18nRequestContext = PathLocale & {
  * Note that this is react-router context, not a React context. Use `RouterContextProvider`
  * to access it.
  */
-export const LocaleContext = createContext<I18nRequestContext>()
+export const LocaleServerContext = createContext<I18nRequestContext>()
 
 /**
  * Server-side i18n context with additional properties.
@@ -57,7 +57,7 @@ export type I18nRouterContext = I18nRequestContext & {
  */
 export function useLinguiServer(context: Readonly<RouterContextProvider>): I18nRouterContext {
   try {
-    const serverContext = context.get(LocaleContext)
+    const serverContext = context.get(LocaleServerContext)
     const pathnamePrefix = serverContext.requestLocale ? `/${serverContext.requestLocale}` : ""
 
     return {

--- a/src/server/middleware.ts
+++ b/src/server/middleware.ts
@@ -4,7 +4,7 @@ import { $detectLocale, $getI18nInstance } from "virtual:lingui-router-loader"
 import { findLocale, stripPathnameLocalePrefix } from "../i18n"
 import { config, loadLocaleCatalog } from "../runtime"
 import "./assert-server"
-import { LocaleContext } from "./context"
+import { LocaleServerContext } from "./context"
 
 /**
  * Locale middleware implementation. Determines the locale from the URL or the
@@ -60,7 +60,7 @@ export async function localeMiddleware(
   }
 
   // Set the locale context
-  context.set(LocaleContext, {
+  context.set(LocaleServerContext, {
     locale: resolvedLocale,
     i18n,
     _: i18n._.bind(i18n),


### PR DESCRIPTION
- Introduced LocalePathContext for locale information derived from the URL path.
- Updated usePathLocale to utilize context instead of direct parameters (improves #84)
- Adjusted I18nApp to provide context for locale management.
- Renamed LocaleContext to LocaleServerContext to clarify its react-router context